### PR TITLE
feat: allow ansys-tools-protoc-helper builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,8 @@ if __name__ == "__main__":
         long_description_content_type="text/markdown",
         url=f"https://github.com/ansys/{package_name}",
         license="MIT",
-        python_requires=">=3.9",
-        install_requires=["grpcio~=1.49", "protobuf>=3.19,<6"],
+        python_requires=">=3.7",
+        install_requires=["grpcio~=1.44", "protobuf>=3.19,<6"],
         packages=setuptools.find_namespace_packages(".", include=("ansys.*",)),
         package_data={
             "": ["*.proto", "*.pyi", "py.typed", "VERSION"],

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
         long_description_content_type="text/markdown",
         url=f"https://github.com/ansys/{package_name}",
         license="MIT",
-        python_requires=">=3.7",
+        python_requires=">=3.10",
         install_requires=["grpcio~=1.44", "protobuf>=3.19,<6"],
         packages=setuptools.find_namespace_packages(".", include=("ansys.*",)),
         package_data={


### PR DESCRIPTION
As title says. This is done in order to allow conda-built packages.